### PR TITLE
Fix mail failures

### DIFF
--- a/bars_transactions/serializers.py
+++ b/bars_transactions/serializers.py
@@ -405,7 +405,7 @@ class RefundTransactionSerializer(BaseTransactionSerializer, AccountAmountSerial
 
         return obj
 
-punishement_notification_mail = {
+punishment_notification_mail = {
     'subject': "[Chocapix] Notification d'amende",
     'message': u"""
 Salut,
@@ -436,7 +436,7 @@ class PunishTransactionSerializer(BaseTransactionSerializer, AccountAmountSerial
         t.save()
 
         ## notify the account owner
-        message = punishement_notification_mail.copy()
+        message = punishment_notification_mail.copy()
         message["from_email"] = t.author.email
         account = operation.target
         if account.owner.email:

--- a/bars_transactions/serializers.py
+++ b/bars_transactions/serializers.py
@@ -406,6 +406,7 @@ class RefundTransactionSerializer(BaseTransactionSerializer, AccountAmountSerial
         return obj
 
 punishment_notification_mail = {
+    'from_email': "babe@eleves.polytechnique.fr",
     'subject': "[Chocapix] Notification d'amende",
     'message': u"""
 Salut,
@@ -437,7 +438,8 @@ class PunishTransactionSerializer(BaseTransactionSerializer, AccountAmountSerial
 
         ## notify the account owner
         message = punishment_notification_mail.copy()
-        message["from_email"] = t.author.email
+        if t.author.email:
+            message["from_email"] = t.author.email
         account = operation.target
         if account.owner.email:
             message["recipient_list"] = [account.owner.email]


### PR DESCRIPTION
When the account creating a "punish" transaction did not have an email set, the default one used for sending the mail was webmaster@localhost ; which caused mail bounces.

This PR should fix this.