### PR TITLE
Changé le prix des sellitems (évite les prix negatifs).

### DIFF
--- a/bars_transactions/serializers.py
+++ b/bars_transactions/serializers.py
@@ -124,16 +124,11 @@ class ItemQtySerializer(serializers.Serializer):
             sellitem = data['sellitem']
             if not sellitem.sell_fraction:
                 qty = math.ceil(qty)
-            total_qty = sellitem.calc_qty()
-            stockitems = sellitem.stockitems.all()
 
             total_price = 0
-            for si in stockitems.all():
-                if total_qty != 0:
-                    delta = (si.sell_qty * qty) / total_qty
-                else:
-                    delta = qty / stockitems.count()
-
+            for (si, si_qty) in sellitem.calc_price_qty_per_stockitem():
+                print("si " + str(si) + " " + str(qty))
+                delta = si_qty * qty
                 si.create_operation(delta=-delta, unit='sell', transaction=t, fuzzy=True)
                 total_price += delta * si.get_price(unit='sell')
 


### PR DESCRIPTION
Voici un commit qui pourrait arranger le problème des prix négatifs. Ça n’est pas parfait, mais ça évitera sans doute quelques problèmes aux Respo Bars.
En gros, on distingue quatre cas :
- tous les stocks sont positifs, on fait comme avant
- certains stocks sont en positif, d’autres en négatif, alors le prix est calculé comme si seuls les aliments en positifs existaient
- tous les stocks sont en négatif, et on fait comme avant
- tout est à zéro, et on fait le prix moyen sans pondération